### PR TITLE
Add browser and node to env

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,8 @@
 module.exports = {
+  env: {
+    browser: true,
+    node: true,
+  },
   extends: [
     'plugin:flowtype/recommended',
     'plugin:react/recommended',


### PR DESCRIPTION
Currently accessing window will make eslint error saying it's undefined. This should setup the expected environments for where we use fusion code.