### PR TITLE
Relax `import/prefer-default-export`

### DIFF
--- a/rules/imports.js
+++ b/rules/imports.js
@@ -106,7 +106,7 @@ module.exports = {
 
     // Require modules with a single export to use a default export
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/prefer-default-export.md
-    'import/prefer-default-export': 'error',
+    'import/prefer-default-export': 'off',
 
     // Restrict which files can be imported in a given folder
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-restricted-paths.md


### PR DESCRIPTION
This rule seems overly opinionated to me and it's not clear to me this prevents errors.

There's definitely other opinions regarding default vs named exports: https://twitter.com/sebmarkbage/status/926290535974932480