### PR TITLE
Remove absolute first from import/first

### DIFF
--- a/rules/imports.js
+++ b/rules/imports.js
@@ -80,7 +80,7 @@ module.exports = {
 
     // disallow non-import statements appearing before import statements
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/first.md
-    'import/first': ['error', 'absolute-first'],
+    'import/first': ['error'],
 
     // disallow duplicate imports
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-duplicates.md


### PR DESCRIPTION
Removing `absolute-first` field from import/first as the order of the imports does not matter. What matters is avoiding any weird knowledge issues when putting code between the imports since imports are hoisted. 

This also unlocks a nice organizational feature for React components where you group your imports
```
// Components - External
...

// Components - Internal
import {Button} from '../button';

// Utiltiies
import * as moment from 'moment';
```