### PR TITLE
decrease import/no-named-as-default rule level from error to warn

### DIFF
--- a/rules/imports.js
+++ b/rules/imports.js
@@ -39,7 +39,7 @@ module.exports = {
 
     // do not allow a default import name to match a named export
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-named-as-default.md
-    'import/no-named-as-default': 'error',
+    'import/no-named-as-default': 'warn',
 
     // warn on accessing default export property names that are also named exports
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-named-as-default-member.md


### PR DESCRIPTION
Rationale, I have a component `Button`, looks like this:

```js
// ...
export class Button extends Component {
// ...
}

export default styled(Button);
```

Except for tests, I 100% of the time do `import Button from 'path/to/my/button'`

With the level for the `import/no-named-as-default` set to `'error'`, I have to do something like `import StyledButon from 'path/to/my/button'`

setting the rule level to "warn" instead of "error" WARNS the user in case they were supposed to import the named export, but if you know that you want the default, you can safely ignore